### PR TITLE
Fix deploy and bust correct cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 0  # allow deriving correct version from git tags
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,18 +58,18 @@ jobs:
       uses: pat-s/always-upload-cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        # cache bust by increasing or resetting (after 7 days) the “vX” tag
-        key: ${{runner.os}}-pip-${{ env.pythonLocation }}-v2-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{runner.os}}-pip-${{ env.pythonLocation }}-v2-
+        key: ${{runner.os}}-pip-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+        restore-keys: ${{runner.os}}-pip-${{ env.pythonLocation }}-
 
     - name: Cache R packages
       uses: pat-s/always-upload-cache@v2
       if: startsWith(runner.os, 'Linux')
       with:
         path: ${{ env.RENV_PATHS_ROOT }}
-        key: ${{ runner.os }}-renv-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('**/renv.lock') }}
+        # cache bust by increasing or resetting (after 7 days) the “vX” tag
+        key: ${{ runner.os }}-renv-${{ steps.setup-r.outputs.installed-r-version }}-v2-${{ hashFiles('**/renv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-renv-${{ steps.setup-r.outputs.installed-r-version }}-
+          ${{ runner.os }}-renv-${{ steps.setup-r.outputs.installed-r-version }}-v2-
 
     - name: Install python tools
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ doc = [
 
 [tool.hatch.version]
 source = 'vcs'
+raw-options = { local_scheme = 'no-local-version' }  # be able to publish dev version
 
 [tool.hatch.build.hooks.vcs]
 version-file = 'src/anndata2ri/_version.py'


### PR DESCRIPTION
Fixes #74 

Problems:

- [x] `setuptools-scm` generates a `+local` fragments for versions not derived from a tag
- [x] The checkout action uses `fetch-depth: 1`, ruining git tags in the process