### PR TITLE
Replace deprecated `rpy2.robjects.conversion.converter`

### DIFF
--- a/src/anndata2ri/conv.py
+++ b/src/anndata2ri/conv.py
@@ -14,7 +14,7 @@ mat_converter = numpy2ri.converter + scipy2ri.converter
 
 def full_converter() -> conversion.Converter:
     pandas2ri.activate()
-    new_converter = conversion.Converter('anndata conversion', template=conversion.converter)
+    new_converter = conversion.Converter('anndata conversion', template=conversion.get_conversion())
     pandas2ri.deactivate()
 
     overlay_converter(scipy2ri.converter, new_converter)
@@ -38,7 +38,7 @@ def activate():
         return
 
     new_converter = full_converter()
-    original_converter = conversion.converter
+    original_converter = conversion.get_conversion()
     conversion.set_conversion(new_converter)
 
 

--- a/src/anndata2ri/scipy2ri/conv.py
+++ b/src/anndata2ri/scipy2ri/conv.py
@@ -19,10 +19,10 @@ def activate():
     if original_converter is not None:
         return
 
-    original_converter = conversion.converter
+    original_converter = conversion.get_conversion()
 
     numpy2ri.activate()
-    new_converter = conversion.Converter('scipy conversion', template=conversion.converter)
+    new_converter = conversion.Converter('scipy conversion', template=conversion.get_conversion())
     numpy2ri.deactivate()
 
     overlay_converter(converter, new_converter)


### PR DESCRIPTION
`conversion.converter` is deprecated. This PR uses the new recommended `get_conversion()` function.

```
anndata2ri.py2rpy(pyobject)
  File "/usr/local/lib/python3.8/site-packages/anndata2ri/__init__.py", line 48, in py2rpy
    return converter.py2rpy(obj)
  File "/usr/local/lib/python3.8/functools.py", line 875, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/usr/local/lib/python3.8/site-packages/anndata2ri/py2r.py", line 70, in py2rpy_anndata
    with localconverter(full_converter() + dict_converter):
  File "/usr/local/lib/python3.8/site-packages/anndata2ri/conv.py", line 17, in full_converter
    new_converter = conversion.Converter('anndata conversion', template=conversion.converter)
  File "/usr/local/lib/python3.8/site-packages/rpy2/robjects/conversion.py", line 28, in __getattr__
    warnings.warn(
DeprecationWarning: The use of converter in module rpy2.robjects.conversion is deprecated. Use rpy2.robjects.conversion.get_conversion() instead of rpy2.robjects.conversion.converter.
```