### PR TITLE
Don’t accept warnings in tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Tests",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "internalConsole",
+            "justMyCode": false,
+        },
+    ],
+}

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Either use the converter manually …
    from rpy2.robjects import r
    from rpy2.robjects.conversion import localconverter
 
-   with localconverter(anndata2ri.full_converter()):
+   with localconverter(anndata2ri.converter):
        adata = r('as(some_data, "SingleCellExperiment")')
 
 … or activate it globally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ run = 'pytest -vv {args}'
 addopts = [
     '--import-mode=importlib',
     '-panndata2ri.test_utils',
-    # TODO '-Werror',
+    '-Werror',
 ]
 filterwarnings = [
     # eventlet 0.24.1 imports dns.hash: https://github.com/eventlet/eventlet/pull/563

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,19 +64,6 @@ addopts = [
     '-panndata2ri.test_utils',
     '-Werror',
 ]
-filterwarnings = [
-    # eventlet 0.24.1 imports dns.hash: https://github.com/eventlet/eventlet/pull/563
-    'ignore::DeprecationWarning:dns.hash',
-    # igraph 0.7.1post6 imports SafeConfigParser: https://github.com/igraph/python-igraph/pull/203
-    'ignore::DeprecationWarning:igraph.configuration',
-    # ipywidgets 7.4.2 imports ABCs from collections: https://github.com/jupyter-widgets/ipywidgets/pull/2395
-    'ignore::DeprecationWarning:ipywidgets.widgets.widget_selection',
-    # jinja2 2.10.1 imports ABCs from collections: https://github.com/pallets/jinja/pull/867
-    'ignore::DeprecationWarning:jinja2.utils',
-    'ignore::DeprecationWarning:jinja2.runtime',
-    # rpy2 3.0.2 imports ABCs from collections: https://bitbucket.org/rpy2/rpy2/pull-requests/74/fix-deprecationwarning/diff
-    'ignore::DeprecationWarning:rpy2.rinterface_lib.sexp',
-]
 
 [tool.black]
 line-length = 120

--- a/src/anndata2ri/_conv.py
+++ b/src/anndata2ri/_conv.py
@@ -18,7 +18,13 @@ if TYPE_CHECKING:
 
 
 original_converter: conversion.Converter | None = None
-converter = conversion.Converter('original anndata conversion')
+converter = (
+    conversion.Converter('original anndata conversion', template=conversion.get_conversion())
+    + numpy2ri.converter
+    + pandas2ri.converter
+    + scipy2ri.converter
+)
+
 
 _mat_converter = numpy2ri.converter + scipy2ri.converter
 
@@ -35,14 +41,6 @@ def mat_py2rpy(obj: np.ndarray | spmatrix | pd.DataFrame) -> Sexp:
 
 
 mat_rpy2py: Callable[[Sexp], np.ndarray | spmatrix | Sexp] = _mat_converter.rpy2py
-
-
-def full_converter() -> conversion.Converter:
-    """Load numpy, pandas, scipy, then ours.
-
-    Overwrite the scipy2ri Sexp4 converter.
-    """
-    return conversion.get_conversion() + numpy2ri.converter + pandas2ri.converter + scipy2ri.converter + converter
 
 
 def activate() -> None:
@@ -66,7 +64,7 @@ def activate() -> None:
     if original_converter is not None:
         return
 
-    new_converter = full_converter()
+    new_converter = converter
     original_converter = conversion.get_conversion()
     conversion.set_conversion(new_converter)
 

--- a/src/anndata2ri/_conv.py
+++ b/src/anndata2ri/_conv.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from warnings import warn
 
 import numpy as np
 import pandas as pd
 from rpy2.robjects import conversion, numpy2ri, pandas2ri
-from rpy2.robjects.conversion import overlay_converter
 
 from . import scipy2ri
 
@@ -25,7 +25,7 @@ _mat_converter = numpy2ri.converter + scipy2ri.converter
 
 def mat_py2rpy(obj: np.ndarray | spmatrix | pd.DataFrame) -> Sexp:
     if isinstance(obj, pd.DataFrame):
-        numeric_cols = obj.dtypes <= np.number
+        numeric_cols = obj.dtypes.map(lambda dt: np.issubdtype(dt, np.number))
         if not numeric_cols.all():
             non_num = numeric_cols.index[~numeric_cols]
             msg = f'DataFrame contains non-numeric columns {list(non_num)}'
@@ -38,15 +38,11 @@ mat_rpy2py: Callable[[Sexp], np.ndarray | spmatrix | Sexp] = _mat_converter.rpy2
 
 
 def full_converter() -> conversion.Converter:
-    pandas2ri.activate()
-    new_converter = conversion.Converter('anndata conversion', template=conversion.get_conversion())
-    pandas2ri.deactivate()
+    """Load numpy, pandas, scipy, then ours.
 
-    overlay_converter(scipy2ri.converter, new_converter)
-    # overwrite the scipy2ri Sexp4 converter and add our others
-    overlay_converter(converter, new_converter)
-
-    return new_converter
+    Overwrite the scipy2ri Sexp4 converter.
+    """
+    return conversion.get_conversion() + numpy2ri.converter + pandas2ri.converter + scipy2ri.converter + converter
 
 
 def activate() -> None:
@@ -58,6 +54,13 @@ def activate() -> None:
 
     Does nothing if this is the active converter.
     """
+    warn(
+        'The global conversion available with activate() '
+        'is deprecated and will be removed in the next major release. '
+        'Use a local converter.',
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     global original_converter  # noqa: PLW0603
 
     if original_converter is not None:

--- a/src/anndata2ri/_py2r.py
+++ b/src/anndata2ri/_py2r.py
@@ -11,7 +11,7 @@ from rpy2.robjects.conversion import localconverter
 from rpy2.robjects.vectors import ListVector
 
 from . import _conv_name
-from ._conv import converter, full_converter, mat_py2rpy
+from ._conv import converter, mat_py2rpy
 from ._rpy2_ext import importr
 
 
@@ -77,7 +77,7 @@ def py2rpy_anndata(obj: AnnData) -> RS4:
         col_data = s4v.DataFrame(**col_args)
 
         # Convert everything we know
-        with localconverter(full_converter() + dict_converter):
+        with localconverter(converter + dict_converter):
             metadata = ListVector(obj.uns.items())
 
         rd_args = {_conv_name.scanpy2sce(k): mat_py2rpy(obj.obsm[k]) for k in obj.obsm}

--- a/src/anndata2ri/_r2py.py
+++ b/src/anndata2ri/_r2py.py
@@ -10,7 +10,7 @@ from rpy2.robjects.conversion import localconverter
 from rpy2.robjects.robject import RSlots
 
 from . import _conv_name
-from ._conv import converter, full_converter, mat_rpy2py
+from ._conv import converter, mat_rpy2py
 from ._rpy2_ext import importr
 from .scipy2ri import supported_r_matrix_classes
 from .scipy2ri._r2py import rmat_to_spmat
@@ -126,7 +126,7 @@ def rpy2py_single_cell_experiment(obj: SexpS4) -> AnnData:
     obs.index = obs.index.astype('string')
     var.index = var.index.astype('string')
     # The whole shebang: configured converter, numpy, pandas and ours
-    with localconverter(full_converter()):
+    with localconverter(converter):
         uns = dict(metadata.items())
 
     return AnnData(exprs, obs, var, uns, obsm, layers=layers)

--- a/src/anndata2ri/_r2py.py
+++ b/src/anndata2ri/_r2py.py
@@ -122,6 +122,9 @@ def rpy2py_single_cell_experiment(obj: SexpS4) -> AnnData:
 
     obs = rpy2py_data_frame(col_data)
     var = rpy2py_data_frame(row_data)
+    # To avoid ImplicitModificationWarning
+    obs.index = obs.index.astype('string')
+    var.index = var.index.astype('string')
     # The whole shebang: configured converter, numpy, pandas and ours
     with localconverter(full_converter()):
         uns = dict(metadata.items())

--- a/src/anndata2ri/scipy2ri/_conv.py
+++ b/src/anndata2ri/scipy2ri/_conv.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from warnings import warn
+
 from rpy2.robjects import conversion, numpy2ri
 from rpy2.robjects.conversion import overlay_converter
 
@@ -13,6 +15,13 @@ def activate() -> None:
 
     Does nothing if this is the active conversion.
     """
+    warn(
+        'The global conversion available with activate() '
+        'is deprecated and will be removed in the next major release. '
+        'Use a local converter.',
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     global original_converter  # noqa: PLW0603
 
     if original_converter is not None:

--- a/src/anndata2ri/scipy2ri/_r2py.py
+++ b/src/anndata2ri/scipy2ri/_r2py.py
@@ -59,7 +59,7 @@ def rmat_to_spmat(rmat: SexpS4) -> sparse.spmatrix:
                 if supported_r_matrix_classes(types='n') & r_classes
                 else slots['x']
             )
-            dtype = np.bool_ if supported_r_matrix_classes(types=('n', 'l')) & r_classes else np.floating
+            dtype = np.bool_ if supported_r_matrix_classes(types=('n', 'l')) & r_classes else np.float_
             return mat_cls((data, *coord_spec), shape=shape, dtype=dtype)
 
         msg = 'Should have hit one of the branches'

--- a/src/anndata2ri/test_utils.py
+++ b/src/anndata2ri/test_utils.py
@@ -49,7 +49,8 @@ def _conversion_py2rpy_local(conv_mod: ConversionModule, dataset: Any) -> Sexp: 
 
 def _conversion_py2rpy_activate(conv_mod: ConversionModule, dataset: Any) -> Sexp:  # noqa: ANN401
     try:
-        conv_mod.activate()
+        with pytest.warns(DeprecationWarning, match=r'global conversion'):
+            conv_mod.activate()
         globalenv['temp'] = dataset
     finally:
         conv_mod.deactivate()

--- a/tests/test_py2rpy.py
+++ b/tests/test_py2rpy.py
@@ -70,7 +70,8 @@ def test_py2rpy2_numpy_pbmc68k() -> None:
     from scanpy.datasets import pbmc68k_reduced
 
     try:
-        anndata2ri.activate()
+        with pytest.warns(DeprecationWarning, match=r'global conversion'):
+            anndata2ri.activate()
         with catch_warnings(record=True) as logs:
             simplefilter('ignore', DeprecationWarning)
             globalenv['adata'] = pbmc68k_reduced()

--- a/tests/test_rpy2py.py
+++ b/tests/test_rpy2py.py
@@ -85,7 +85,7 @@ def test_convert_empty_df_with_rows(r2py: R2Py) -> None:
     df = r('S4Vectors::DataFrame(a=1:10)[, -1]')
     assert df.slots['nrows'][0] == 10
 
-    df_py = r2py(anndata2ri, lambda: conversion.rpy2py(df))
+    df_py = r2py(anndata2ri, lambda: conversion.get_conversion().rpy2py(df))
     assert isinstance(df_py, pd.DataFrame)
 
 

--- a/tests/test_scipy_rpy2py.py
+++ b/tests/test_scipy_rpy2py.py
@@ -49,10 +49,10 @@ ngt = partial(r, 'Matrix::sparseMatrix(1:2, 3:2, dims = c(3, 3), giveCsparse = F
 coo_b2 = [[0, 0, 1], [0, 1, 0], [0, 0, 0]]
 
 mats = [
-    pytest.param((0, 0), sparse.csc_matrix, np.floating, csc_empty, dgc_empty, id='dgC_empty'),
-    pytest.param((3, 2), sparse.csc_matrix, np.floating, csc_f, dgc, id='dgC'),
-    pytest.param((2, 3), sparse.csr_matrix, np.floating, csr_f, dgr, id='dgR'),
-    pytest.param((2, 3), sparse.coo_matrix, np.floating, coo_f, dgt, id='dgT'),
+    pytest.param((0, 0), sparse.csc_matrix, np.float_, csc_empty, dgc_empty, id='dgC_empty'),
+    pytest.param((3, 2), sparse.csc_matrix, np.float_, csc_f, dgc, id='dgC'),
+    pytest.param((2, 3), sparse.csr_matrix, np.float_, csr_f, dgr, id='dgR'),
+    pytest.param((2, 3), sparse.coo_matrix, np.float_, coo_f, dgt, id='dgT'),
     pytest.param((2, 3), sparse.csc_matrix, np.bool_, csc_b1, lgc, id='lgC'),
     pytest.param((3, 3), sparse.csr_matrix, np.bool_, csr_b1, lgr, id='lgR'),
     # pytest.param((?, ?), sparse.coo_matrix, np.bool_, coo_b1, lgt, id="lgT"),


### PR DESCRIPTION
Fixes #125

TODO:

- [x] turn on `-Werror`
- [x] fix warnings
- [x] remove all no longer necessary `filterwarnings` entries in pyproject.toml