### PR TITLE
fix: don’t crash when checking for numeric dtypes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,4 +14,6 @@
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": ["--color=yes", "-vv"],
     "python.terminal.activateEnvironment": true,
+    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
+    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
 }

--- a/src/anndata2ri/_conv.py
+++ b/src/anndata2ri/_conv.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 import pandas as pd
 from rpy2.robjects import conversion, numpy2ri, pandas2ri
 
@@ -12,6 +11,7 @@ from . import scipy2ri
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import numpy as np
     from rpy2.rinterface import Sexp
     from scipy.sparse import spmatrix
 
@@ -26,7 +26,7 @@ _mat_converter = numpy2ri.converter + scipy2ri.converter
 
 def mat_py2rpy(obj: np.ndarray | spmatrix | pd.DataFrame) -> Sexp:
     if isinstance(obj, pd.DataFrame):
-        numeric_cols = obj.dtypes.map(lambda dt: np.issubdtype(dt, np.number))
+        numeric_cols = obj.dtypes.map(pd.api.types.is_numeric_dtype)
         if not numeric_cols.all():
             non_num = numeric_cols.index[~numeric_cols]
             msg = f'DataFrame contains non-numeric columns {list(non_num)}'

--- a/tests/test_rpy2py.py
+++ b/tests/test_rpy2py.py
@@ -23,12 +23,15 @@ if TYPE_CHECKING:
 as_ = getattr(importr('methods'), 'as')
 se = importr('SummarizedExperiment')
 sce = importr('SingleCellExperiment')
-eh = importr('ExperimentHub')
-seq = importr('scRNAseq')
 
 
-# avoid prompt
-Path(eh.getExperimentHubOption('CACHE')[0]).mkdir(parents=True, exist_ok=True)
+def get_allen() -> Sexp:
+    eh = importr('ExperimentHub')
+    seq = importr('scRNAseq')
+
+    # avoid prompt
+    Path(eh.getExperimentHubOption('CACHE')[0]).mkdir(parents=True, exist_ok=True)
+    return as_(seq.ReprocessedAllenData(assays='tophat_counts'), 'SingleCellExperiment')
 
 
 def check_allen(adata: AnnData) -> None:
@@ -57,12 +60,7 @@ local({
 """
 
 expression_sets = [
-    pytest.param(
-        check_allen,
-        (379, 20816),
-        lambda: as_(seq.ReprocessedAllenData(assays='tophat_counts'), 'SingleCellExperiment'),
-        id='allen',
-    ),
+    pytest.param(check_allen, (379, 20816), get_allen, id='allen'),
     pytest.param(lambda _: None, (0, 0), sce.SingleCellExperiment, id='empty'),
     pytest.param(check_example, (100, 200), lambda: r(code_example), id='example'),
 ]


### PR DESCRIPTION
we still crash afterwards, but with a good message